### PR TITLE
Fix/8 inline without width

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,19 @@ The resulting HTML will be:
 
 #### .gatsby-img-attributes
 
-Generated markup will always have a CSS class `gatsby-img-attributes`. The plugin itself does not come with any attributes for that class; you can use it freely to apply default styling to all images with attributes.
-
+Generated markup will always have a CSS class `gatsby-img-attributes`. The plugin itself does not come with any attributes for that class; you can use it to apply default styling to all images with attributes.
 
 ## Examples
 
 ### styleAttributes
 
-You can use the `styleAttributes` option to define CSS style names to be recognized and applied by the plugin.
+Use the `styleAttributes` option to define CSS style names to be recognized and applied by the plugin!
 
 You can set this to `true` to use [W3's official list of CSS properties](https://www.w3.org/Style/CSS/all-properties.en.html#list) (~530 names) as `styleAttributes`.
 
 ---
 
-To add only specific properties to the defaults, declare e.g. `position`, `top` and `left` in your _gatsby-config.js_:
+Declare e.g. `position`, `top` and `left` in your _gatsby-config.js_:
 
 ```js
 plugins: [

--- a/README.md
+++ b/README.md
@@ -28,22 +28,18 @@ plugins: [
           resolve: `gatsby-remark-image-attributes`,
           options: {
 
-            // ?Array<String> | Boolean
-            //   Any names declared here are added
-            //   to the default set of attributes
-            //   which the plugin will use to style
-            //   the image.
-            //   If this is set to true, all CSS
+            // ?Boolean=true
+            //   If true (the default), all CSS
             //   property names will be recognized
             //   as styleAttribute.
-            styleAttributes: [`display`, `position`, `border`],
+            styleAttributes: true,
 
-            // ?Boolean
+            // ?Boolean=false
             //   If true, all attributes that
             //   aren't styleAttributes, will be
             //   added as data-* attributes to the
             //   image.
-            dataAttributes: true
+            dataAttributes: false
           }
         }
       ]
@@ -74,63 +70,22 @@ The resulting HTML will be:
 
 |Name|Type|Default|Description|
 |:-:|:-:|:-:|-|
-| styleAttributes | Array\<String\> \| Boolean | `['width', 'height', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom', 'float']` | _Array\<String\>_<br />Any valid CSS style name you want to apply to an image. This option adds to the defaults, i.e. it can be omitted when only the defaults are needed. <br /><br />-OR-<br /><br />_Boolean_<br />Add _[all](https://www.w3.org/Style/CSS/all-properties.en.html#list)_ CSS properties to styleAttributes.
-| dataAttributes  |Boolean| `false` | Add all attributes not recognized as styleAttribute as data- attribute to the image.
+| [styleAttributes](#styleattributes) | Boolean | `true` | Set to `false` if you want to disable [CSS properties](https://www.w3.org/Style/CSS/all-properties.en.html#list) being added to the images style attribute.
+| [dataAttributes](#dataattributes) |Boolean| `false` | Set to `true` if you want attributes not recognized as styleAttribute to be added as data- attribute to the image.
 
 #### .gatsby-img-attributes
 
-Generated markup will always have a CSS class `gatsby-img-attributes`. The plugin itself does not come with any attributes for that class; you can use it to apply default styling to all images with attributes.
+Generated markup has a CSS class `gatsby-img-attributes`. The plugin itself does not come with any attributes for that class; you can use it to apply default styling to all images with attributes.
 
-## Examples
+#### styleAttributes
 
-### styleAttributes
+***NOTE:*** `options.styleAttributes` used to accept an `Array<String>`, its items extending a default set of recognized properties, e.g. `styleAttributes: ['position', 'top', 'left']`. This still works, but sets `styleAttributes: true`, enabling all CSS properties.
 
-Use the `styleAttributes` option to define CSS style names to be recognized and applied by the plugin!
+The plugin uses a [list of all CSS properties](https://github.com/rbeer/gatsby-remark-image-attributes/blob/master/src/css-props.json), as defined by the [W3C](https://www.w3.org/Style/CSS/all-properties.en.html), to decide whether an attribute is to be added to the image's style or not.
 
-You can set this to `true` to use [W3's official list of CSS properties](https://www.w3.org/Style/CSS/all-properties.en.html#list) (~530 names) as `styleAttributes`.
+#### dataAttributes
 
----
-
-Declare e.g. `position`, `top` and `left` in your _gatsby-config.js_:
-
-```js
-plugins: [
-  {
-    resolve: `gatsby-transformer-remark`,
-    options: {
-      plugins: [
-        {
-          resolve: `gatsby-remark-image-attributes`,
-          options: {
-            styleAttributes: [`position`, `top`, `left`]
-          }
-        }
-      ]
-    }
-  }
-];
-```
-
-so you then can use them as attributes on an image
-
-```md
-![happy](https://foomoji.com/happy.png#position=absolute;top=20px;left=10px)
-```
-
-producing
-
-```html
-<img
-  src="https://foomoji.com/happy.png"
-  alt="happy"
-  style="position: absolute; top: 20px; left: 10px;"
-  class="gatsby-img-attributes"
-/>
-```
-
-### dataAttributes
-
-When `options.dataAttributes` is `true`, the plugin will add all attributes whose key isn't in `options.styleAttributes` as data-* attribute to the image.
+When `options.dataAttributes` is `true`, the plugin will add all attributes whose key isn't a [CSS property](https://www.w3.org/Style/CSS/all-properties.en.html#list) as data-* attribute to the image.
 
 _gatsby-config.js_:
 
@@ -156,19 +111,51 @@ _md_:
 ```md
 ![happy](https://foomoji.com/happy.png#tool-tip=Fancy image with tooltip;position=absolute;height=100px)
 ```
-Where `height` is recognized as `styleAttribute` - because it is one of the defaults -, `tool-tip` _and_ `position` are not and thus applied as `dataAttributes`:
+Where `position` and `height` are recognized as `styleAttributes`, `tool-tip` is not and thus applied as `data-` attribute:
 
 ```html
 <img
   src="https://foomoji.com/happy.png"
   alt="happy"
-  style="height: 100px;"
+  style="position: absolute; height: 100px;"
   data-tool-tip="Fancy image with tooltip"
-  data-position="absolute"
   class="gatsby-img-attributes"
 />
 ```
 
+With `options.styleAttributes === false`, valid [CSS properties](https://www.w3.org/Style/CSS/all-properties.en.html#list) become `data-` attributes:
+
+```js
+plugins: [
+  {
+    resolve: `gatsby-transformer-remark`,
+    options: {
+      plugins: [
+        {
+          resolve: `gatsby-remark-image-attributes`,
+          options: {
+            styleAttributes: false,
+            dataAttributes: true
+          }
+        }
+      ]
+    }
+  }
+];
+```
+```md
+![happy](https://foomoji.com/happy.png#tool-tip=Fancy image with tooltip;position=absolute;height=100px)
+```
+```html
+<img
+  src="https://foomoji.com/happy.png"
+  alt="happy"
+  data-tool-tip="Fancy image with tooltip"
+  data-position="absolute"
+  data-height="100px"
+  class="gatsby-img-attributes"
+/>
+```
 ### use with gatsby-remark-images
 
 This plugin can handle already processed images (type: 'html'), as long as the node object contains an `attributes` field and the `value` an `<img />` tag.
@@ -193,7 +180,6 @@ plugins: [
         {
           resolve: `gatsby-remark-image-attributes`,
           options: {
-            styleAttributes: [`box-shadow`],
             dataAttributes: true
           }
         }
@@ -235,7 +221,7 @@ You might have noticed that `styleAttributes` and `class="gatsby-img-attributes"
 
 ### use with gatsby-plugin-mdx
 
-If you want to use MDX instead of the bare remark transformer, you have to add `gatsby-remark-image-attributes` to [`options.gatsbyRemarkPlugins`](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#gatsby-remark-plugins) of `gatsby-plugin-mdx`.
+Add `gatsby-remark-image-attributes` to [`options.gatsbyRemarkPlugins`](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#gatsby-remark-plugins) of `gatsby-plugin-mdx`.
 
 _gatsby-config.js_
 ```js
@@ -261,7 +247,8 @@ _gatsby-config.js_
           {
             resolve: "gatsby-remark-image-attributes",
             options: {
-              styleAttributes: ["box-shadow", "position"]
+              // styleAttributes: true,
+              // dataAttributes: false
             }
           }
         ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/runtime": "^7.11.2",
     "lodash.isstring": "^4.0.1",
     "lodash.uniq": "^4.5.0",
-    "remark-image-attributes": "^0.2.0",
+    "remark-image-attributes": "^0.2.1",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,3 +20,4 @@ export declare function createDataAttributes(
   attributes: ImageAttributes
 ): string;
 export declare function isImageHtml(node: any): boolean;
+export declare function findWidth(value: string): string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,4 +19,4 @@ export declare function createStyle(attributes: ImageAttributes): string;
 export declare function createDataAttributes(
   attributes: ImageAttributes
 ): string;
-export declare function isGatsbyRemarkImagesHtml(node: any): boolean;
+export declare function isImageHtml(node: any): boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -58,14 +58,14 @@ const categorizeAttributes = attributes => {
   return { styleAttributes, dataAttributes };
 };
 
-const createStyle = (styleAttributes, inline) => {
+const createStyle = (styleAttributes, inline, width) => {
   let styleString = Object.keys(styleAttributes).reduce(
     (style, key) => `${style}${key}: ${styleAttributes[key]};`,
     ''
   );
 
   if (inline && !styleAttributes.width && !styleAttributes.height) {
-    styleString += 'width: 100%;';
+    styleString += `width: ${width};`;
   }
   return styleString;
 };
@@ -83,11 +83,15 @@ const createImgMarkup = ({ attributes, url, alt, inline }) => {
   }" alt="${alt}" ${createDataAttributes(dataAttributes)} />`;
 };
 
+const findWidth = value =>
+  (value.match(/width: (\d*(px|%|vw))/) || [, '100%'])[1];
+
 const wrapImgMarkup = ({ attributes, value, inline }) => {
+  const width = findWidth(value);
   const { styleAttributes, dataAttributes } = categorizeAttributes(attributes);
   return `<span class="gatsby-img-attributes" style="display:${
     inline ? 'inline-block' : 'block'
-  }; ${createStyle(styleAttributes, inline)}">${value.replace(
+  }; ${createStyle(styleAttributes, inline, width)}">${value.replace(
     /<img[^>]*/,
     `$& ${createDataAttributes(dataAttributes)}`
   )}</span>`;

--- a/src/index.js
+++ b/src/index.js
@@ -13,35 +13,26 @@ const logMsg = (strings, ...expressions) => {
   return `[gatsby-remark-image-attributes] ${message}`;
 };
 
-const _options = {
-  styleAttributes: [
-    'width',
-    'height',
-    'margin-left',
-    'margin-right',
-    'margin-top',
-    'margin-bottom',
-    'float'
-  ],
+const options = {
+  styleAttributes: [],
   dataAttributes: false
 };
 
-const applyOptions = ({ styleAttributes, dataAttributes }, reporter) => {
-  if (styleAttributes) {
-    if (Array.isArray(styleAttributes)) {
-      _options.styleAttributes = uniq(
-        _options.styleAttributes.concat(styleAttributes.filter(isString))
-      );
-    } else if (styleAttributes === true) {
-      _options.styleAttributes = allCSSProperties;
-    } else {
-      reporter.warn(
-        logMsg`Option styleAttributes must be an Array of strings or 'true'.`
-      );
-    }
+const applyOptions = (
+  { styleAttributes = true, dataAttributes = false },
+  reporter
+) => {
+  const styleAttributesIsArray = Array.isArray(styleAttributes);
+  if (styleAttributesIsArray) {
+    reporter.warn(
+      logMsg`Passing Array<String> to styleAttributes is deprecated.`
+    );
+    reporter.warn(logMsg`Using all CSS properties.`);
   }
+  options.styleAttributes =
+    styleAttributes === true || styleAttributesIsArray ? allCSSProperties : [];
 
-  _options.dataAttributes = dataAttributes === true;
+  options.dataAttributes = dataAttributes === true;
 };
 
 const isImageHtml = node => {
@@ -57,9 +48,9 @@ const categorizeAttributes = attributes => {
   const dataAttributes = {};
 
   for (const attributeKey in attributes) {
-    if (_options.styleAttributes.includes(attributeKey)) {
+    if (options.styleAttributes.includes(attributeKey)) {
       styleAttributes[attributeKey] = attributes[attributeKey];
-    } else if (_options.dataAttributes) {
+    } else if (options.dataAttributes) {
       dataAttributes[attributeKey] = attributes[attributeKey];
     }
   }
@@ -102,8 +93,8 @@ const wrapImgMarkup = ({ attributes, value, inline }) => {
   )}</span>`;
 };
 
-module.exports = ({ markdownAST, reporter }, options) => {
-  applyOptions(options, reporter);
+module.exports = ({ markdownAST, reporter }, userOptions) => {
+  applyOptions(userOptions, reporter);
 
   const imageHtml = [];
   visit(markdownAST, 'html', node => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2096,10 +2096,10 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
-remark-image-attributes@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/remark-image-attributes/-/remark-image-attributes-0.2.0.tgz#033cd36951e36472b2f3af1f271a78610f950374"
-  integrity sha512-xz15f4NkfeCkIRHj8VOgMh2PqE2cMINb5p2M0oju139imcRQ01JJHTwbcuDhGhXZZC1vewIoSNGokzkC3HwMLA==
+remark-image-attributes@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/remark-image-attributes/-/remark-image-attributes-0.2.1.tgz#f33941577470a3c368dfbd14cb426d0a8ba0312f"
+  integrity sha512-g8TbKWzy0dBAWXrgPW8SmwbehY+1H8TsTtDB9PJr32hqz6joFCSFMCuTI8QqK9+yErBrQv635ksndeO9OTSIVw==
   dependencies:
     unist-util-select "^3.0.1"
 


### PR DESCRIPTION
Set explicit width on inline images, which is either found in the html node's value or set to `100%`.

fixes #8